### PR TITLE
Issue 46

### DIFF
--- a/src/backend/TradeManager.mo
+++ b/src/backend/TradeManager.mo
@@ -1,58 +1,59 @@
-import Result            "mo:base/Result";
-import Int               "mo:base/Int";
-import Time              "mo:base/Time";
-import Nat64             "mo:base/Nat64";
-import Debug             "mo:base/Debug";
+import Result "mo:base/Result";
+import Int "mo:base/Int";
+import Time "mo:base/Time";
+import Nat64 "mo:base/Nat64";
+import Debug "mo:base/Debug";
 
-import ICRC7             "mo:icrc7-mo";
+import ICRC7 "mo:icrc7-mo";
 
-import BIP721Ledger      "canister:bip721_ledger";
-import BQCLedger         "canister:bqc_ledger";
+import BIP721Ledger "canister:bip721_ledger";
+import BQCLedger "canister:bqc_ledger";
 
 module {
 
-  type Result<Ok, Err>     = Result.Result<Ok, Err>;
-  type Time                = Int;
+type Result<Ok, Err> = Result.Result<Ok, Err>;
+type Time = Int;
 
-  type Account             = ICRC7.Account;
+type Account = ICRC7.Account;
 
-  type Royalties = {
-    percentage: Nat;
-    receiver: Principal;
-  };
+type Royalties = {
+  percentage : Nat;
+  receiver : Principal;
+};
 
-  type TransferArgs = {
-    buyer: Account;
-    seller: Account;
-    token_id: Nat;
-    e8s_price: Nat;
-  };
+type TransferArgs = {
+  buyer : Account;
+  seller : Account;
+  token_id : Nat;
+  e8s_price : Nat;
+};
 
-  type TradeArgs = TransferArgs and {
-    royalties: ?Royalties;
-  };
+type TradeArgs = TransferArgs and {
+  royalties : ?Royalties;
+};
 
-  public class TradeManager({
-    stage_account: Account;
-    fee: Nat;
-  }) {
+public class TradeManager({
+  stage_account : Account;
+  fee : Nat;
+}) {
 
-    public func tradeIntProp(args: TradeArgs) : async* Result<(), Text> {
+  public func tradeIntProp(args : TradeArgs) : async* Result<(), Text> {
 
-      switch(await* stageTransfer(args)){
-        case(#err(err)){ return #err(err); };
-        case(#ok){};
-      };
-
-      await* executeTransfer(args);
-
-      #ok;
+    switch (await* stageTransfer(args)) {
+      case (#err(err)) { return #err(err) };
+      case (#ok) {};
     };
 
-    func stageTransfer(args: TransferArgs) : async* Result<(), Text> {
+    await* executeTransfer(args);
 
-      let { buyer: Account; seller: Account; token_id: Nat; e8s_price: Nat; } = args;
+    #ok;
+  };
 
+  func stageTransfer(args : TransferArgs) : async* Result<(), Text> {
+
+    let { buyer : Account; seller : Account; token_id : Nat; e8s_price : Nat } = args;
+
+    if (e8s_price > 0) {
       // Transfer ICPs to the stage account
       let icp_transfer = await BQCLedger.icrc2_transfer_from({
         from = buyer;
@@ -64,24 +65,20 @@ module {
         created_at_time = ?Nat64.fromNat(Int.abs(Time.now()));
       });
 
-      switch(icp_transfer){
-        case(#Err(err)){ return #err("Transfer of ICP failed: " # debug_show(err)); };
-        case(#Ok(_)){};
+      switch (icp_transfer) {
+        case (#Err(err)) {
+          return #err("Transfer of ICP failed: " # debug_show (err));
+        };
+        case (#Ok(_)) {};
       };
+    };
 
-      // Transfer the intellectual property to the stage account
-      let ip_transfer = extractSingleTransfer(await BIP721Ledger.icrc37_transfer_from([{
-        spender_subaccount = null;
-        from = seller;
-        to = stage_account;
-        token_id;
-        memo = null;
-        created_at_time = ?Nat64.fromNat(Int.abs(Time.now()));
-      }]));
+    let ip_transfer = extractSingleTransfer(await BIP721Ledger.icrc37_transfer_from([{ spender_subaccount = null; from = seller; to = stage_account; token_id; memo = null; created_at_time = ?Nat64.fromNat(Int.abs(Time.now())) }]));
 
-      switch(ip_transfer){
-        case(#err(err)){ 
-          
+    switch (ip_transfer) {
+      case (#err(err)) {
+        // Only reimburse if there was actually a payment
+        if (e8s_price > 0) {
           // Reimburse the buyer if the transfer of the intellectual property failed
           let icp_reimbursement = await BQCLedger.icrc1_transfer({
             from_subaccount = stage_account.subaccount;
@@ -93,67 +90,83 @@ module {
           });
 
           // Log the reimbursement error if it failed
-          switch(icp_reimbursement){
-            case(#Err(err)){ Debug.print("Reimbursement of ICP failed: " # debug_show(err)); };
-            case(#Ok(_)){};
+          switch (icp_reimbursement) {
+            case (#Err(err)) {
+              Debug.print("Reimbursement of ICP failed: " # debug_show (err));
+            };
+            case (#Ok(_)) {};
           };
-
-          return #err(err); 
         };
-        case(#ok){ #ok; };
+
+        return #err(err);
       };
+      case (#ok) { #ok };
     };
 
-    func executeTransfer(args: TradeArgs) : async* () {
+  };
 
-      let { buyer: Account; seller: Account; token_id: Nat; e8s_price: Nat; royalties: ?Royalties; } = args;
+  func executeTransfer(args : TradeArgs) : async* () {
 
-      // Transfer the intellectual property to the buyer
-      let ip_transfer = extractSingleTransfer(await BIP721Ledger.icrc7_transfer([{
-        from_subaccount = stage_account.subaccount;
-        to = buyer;
-        token_id;
-        memo = null;
-        created_at_time = ?Nat64.fromNat(Int.abs(Time.now()));
-      }]));
-      
-      switch((ip_transfer)){
-        case(#err(err)){ Debug.print("Transfer of IP failed: " # debug_show(err)); };
-        case(#ok(_)){};
+    let {
+      buyer : Account;
+      seller : Account;
+      token_id : Nat;
+      e8s_price : Nat;
+      royalties : ?Royalties;
+    } = args;
+
+    // Transfer the intellectual property to the buyer
+    let ip_transfer = extractSingleTransfer(await BIP721Ledger.icrc7_transfer([{ from_subaccount = stage_account.subaccount; to = buyer; token_id; memo = null; created_at_time = ?Nat64.fromNat(Int.abs(Time.now())) }]));
+
+    switch ((ip_transfer)) {
+      case (#err(err)) {
+        Debug.print("Transfer of IP failed: " # debug_show (err));
       };
+      case (#ok(_)) {};
+    };
 
-      var seller_amount = e8s_price;
+    // Skip payment logic if it's free
+    if (e8s_price == 0) {
+      return;
+    };
 
-      switch(royalties){
-        case(null){};
-        case(?{ percentage; receiver }){
+    var seller_amount = e8s_price;
 
-          if (receiver != seller.owner){
-            // Calculate the royalties
-            let royalties_amount = (seller_amount * percentage) / 100;
+    switch (royalties) {
+      case (null) {};
+      case (?{ percentage; receiver }) {
+        if (receiver != seller.owner) {
+          // Calculate the royalties
+          let royalties_amount = (seller_amount * percentage) / 100;
 
+          // Only transfer royalties if amount is greater than fee
+          if (royalties_amount > fee) {
             // Transfer ICPs to the receiver of the royalties
-            // TODO: One should find a way to set the subaccount of the receiver
             let royalties_transfer = await BQCLedger.icrc1_transfer({
               from_subaccount = stage_account.subaccount;
-              to = { owner = receiver; subaccount = null; };
+              to = { owner = receiver; subaccount = null };
               amount = royalties_amount - fee;
               fee = null;
               memo = null;
               created_at_time = ?Nat64.fromNat(Int.abs(Time.now()));
             });
 
-            switch(royalties_transfer){
-              case(#Err(err)){ Debug.print("Transfer of royalties failed: " # debug_show(err)); };
-              case(#Ok(_)){};
+            switch (royalties_transfer) {
+              case (#Err(err)) {
+                Debug.print("Transfer of royalties failed: " # debug_show (err));
+              };
+              case (#Ok(_)) {};
             };
 
-            // Do not forget to subtract the royalties from the amount to be transferred to the seller
+            // Subtract the royalties from the amount to be transferred to the seller
             seller_amount -= royalties_amount;
           };
         };
       };
+    };
 
+    // Only transfer to seller if amount is greater than fee
+    if (seller_amount > fee) {
       // Transfer the ICPs to the seller
       let icp_transfer = await BQCLedger.icrc1_transfer({
         from_subaccount = stage_account.subaccount;
@@ -164,26 +177,27 @@ module {
         created_at_time = ?Nat64.fromNat(Int.abs(Time.now()));
       });
 
-      switch(icp_transfer){
-        case(#Err(err)){ Debug.print("Transfer of ICP failed: " # debug_show(err)); };
-        case(#Ok(_)){};
+      switch (icp_transfer) {
+        case (#Err(err)) {
+          Debug.print("Transfer of ICP failed: " # debug_show (err));
+        };
+        case (#Ok(_)) {};
       };
     };
-
   };
 
-  func extractSingleTransfer(ip_transfers: [?BIP721Ledger.TransferFromResult]) : Result<(), Text> {
-    if (ip_transfers.size() == 0 or ip_transfers[0] == null){
+  func extractSingleTransfer(ip_transfers : [?BIP721Ledger.TransferFromResult]) : Result<(), Text> {
+    if (ip_transfers.size() == 0 or ip_transfers[0] == null) {
       return #err("Transfer of IP failed");
     };
-    let transfer = switch(ip_transfers[0]){
-      case(null) { return #err("Transfer of IP failed"); };
-      case(?tx) { tx };
+    let transfer = switch (ip_transfers[0]) {
+      case (null) { return #err("Transfer of IP failed") };
+      case (?tx) { tx };
     };
-    switch(transfer){
-      case(#Err(err)){ #err("Transfer of IP failed: " # debug_show(err)); };
-      case(#Ok(_)){ #ok; };
+    switch (transfer) {
+      case (#Err(err)) { #err("Transfer of IP failed: " # debug_show (err)) };
+      case (#Ok(_)) { #ok };
     };
   };
-
+  }
 };


### PR DESCRIPTION
This branch is for issue 46. The Users can now list IPs for free. I am kinda torn between let else and switch. The motoko team encourages the use of let else over switches. It is more "efficient" and less verbose. But I guess you do lose some descriptive errors in some cases so I left it in most of the logic here. I also ran the prettier extension on the Trade manager file so that's why the diff is long.


The fix works in the trade manager and in the controller. A user cannot list an IP for free if it has royalties. Listing an ip can now be listed for free and won't fail because it won't attempt to transfer ICP for 0. The appropriate adjustments on the frontend should be made.